### PR TITLE
Fastdds security bugfix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -252,7 +252,7 @@ jobs:
           DISTRIBUTION: jammy
           COMPONENT: fog-sw-sros
           ARCHITECTURE: amd64
-          BUILD_NAME: ${{ matrix.package }}
+          BUILD_NAME: fastdds_libraries
           CI: true
         run: |
           set -exu


### PR DESCRIPTION
This version of Fast-DDS includes a fix for the SROS node launch problems. Detailed information below;

https://github.com/eProsima/Fast-DDS/pull/3362